### PR TITLE
use buit-in detach

### DIFF
--- a/tutorials/08 - Language Model/main-gpu.py
+++ b/tutorials/08 - Language Model/main-gpu.py
@@ -61,7 +61,7 @@ optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
 
 # Truncated Backpropagation 
 def detach(states):
-    return [Variable(state.data) for state in states] 
+    return [state.detach() for state in states] 
 
 # Training
 for epoch in range(num_epochs):

--- a/tutorials/08 - Language Model/main.py
+++ b/tutorials/08 - Language Model/main.py
@@ -61,7 +61,7 @@ optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
 
 # Truncated Backpropagation 
 def detach(states):
-    return [Variable(state.data) for state in states] 
+    return [state.detach() for state in states] 
 
 # Training
 for epoch in range(num_epochs):

--- a/tutorials/10 - Generative Adversarial Network/main-gpu.py
+++ b/tutorials/10 - Generative Adversarial Network/main-gpu.py
@@ -77,7 +77,7 @@ for epoch in range(200):
         
         noise = Variable(torch.randn(images.size(0), 128)).cuda()
         fake_images = generator(noise)
-        outputs = discriminator(fake_images) 
+        outputs = discriminator(fake_images.detach()) 
         fake_loss = criterion(outputs, fake_labels)
         fake_score = outputs
         

--- a/tutorials/10 - Generative Adversarial Network/main.py
+++ b/tutorials/10 - Generative Adversarial Network/main.py
@@ -77,7 +77,7 @@ for epoch in range(200):
         
         noise = Variable(torch.randn(images.size(0), 128))
         fake_images = generator(noise)
-        outputs = discriminator(fake_images) 
+        outputs = discriminator(fake_images.detach()) 
         fake_loss = criterion(outputs, fake_labels)
         fake_score = outputs
         

--- a/tutorials/11 - Deep Convolutional Generative Adversarial Network/main-gpu.py
+++ b/tutorials/11 - Deep Convolutional Generative Adversarial Network/main-gpu.py
@@ -102,7 +102,7 @@ for epoch in range(50):
         
         noise = Variable(torch.randn(images.size(0), 128)).cuda()
         fake_images = generator(noise)
-        outputs = discriminator(fake_images) 
+        outputs = discriminator(fake_images.detach()) 
         fake_loss = criterion(outputs, fake_labels)
         fake_score = outputs
         

--- a/tutorials/11 - Deep Convolutional Generative Adversarial Network/main.py
+++ b/tutorials/11 - Deep Convolutional Generative Adversarial Network/main.py
@@ -102,7 +102,7 @@ for epoch in range(50):
         
         noise = Variable(torch.randn(images.size(0), 128))
         fake_images = generator(noise)
-        outputs = discriminator(fake_images) 
+        outputs = discriminator(fake_images.detch()) 
         fake_loss = criterion(outputs, fake_labels)
         fake_score = outputs
         


### PR DESCRIPTION
For truncated BPTT, use built-in detach
For GANs, detach variables of fake images (thus no useless backprop) when training discriminator.