### PR TITLE
fixed a minor error in vae

### DIFF
--- a/tutorials/03-advanced/variational_auto_encoder/main.py
+++ b/tutorials/03-advanced/variational_auto_encoder/main.py
@@ -65,7 +65,7 @@ data_iter = iter(data_loader)
 # fixed inputs for debugging
 fixed_z = to_var(torch.randn(100, 20))
 fixed_x, _ = next(data_iter)
-torchvision.utils.save_image(fixed_x.data.cpu(), './data/real_images.png')
+torchvision.utils.save_image(fixed_x.cpu(), './data/real_images.png')
 fixed_x = to_var(fixed_x.view(fixed_x.size(0), -1))
 
 for epoch in range(50):


### PR DESCRIPTION
PyTorch: v0.1.12
Python: v2.7

The original code does not work due to line 68:

Traceback (most recent call last):
    File "main.py", line 68, in <module>
        torchvision.utils.save_image(fixed_x.data.cpu(), './data/real_images.png')
AttributeError: 'torch.FloatTensor' object has no attribute 'data'

fixed the error by changing 'fixed_x.data' -> 'fixed_x'