### PR TITLE
converting string to raw string

### DIFF
--- a/tutorials/01-basics/feedforward_neural_network/main.py
+++ b/tutorials/01-basics/feedforward_neural_network/main.py
@@ -16,12 +16,12 @@ batch_size = 100
 learning_rate = 0.001
 
 # MNIST dataset 
-train_dataset = torchvision.datasets.MNIST(root='../../data', 
+train_dataset = torchvision.datasets.MNIST(root=r'../../data', 
                                            train=True, 
                                            transform=transforms.ToTensor(),  
                                            download=True)
 
-test_dataset = torchvision.datasets.MNIST(root='../../data', 
+test_dataset = torchvision.datasets.MNIST(root=r'../../data', 
                                           train=False, 
                                           transform=transforms.ToTensor())
 


### PR DESCRIPTION
will help save unnecessary waste of time on a puny error, specially for beginners