### PR TITLE
Fixed Test error when encoder(image).

### DIFF
--- a/tutorials/03-advanced/image_captioning/sample.py
+++ b/tutorials/03-advanced/image_captioning/sample.py
@@ -14,7 +14,7 @@ from PIL import Image
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 def load_image(image_path, transform=None):
-    image = Image.open(image_path)
+    image = Image.open(image_path).convert('RGB')
     image = image.resize([224, 224], Image.LANCZOS)
     
     if transform is not None:


### PR DESCRIPTION
When we load an image for the sample, we have to make sure that the image has three color channel (RGB) because it might be grayscale. So we should convert it for sampling.