### PR TITLE
<Fixed a bug in accuracy calculation>

### DIFF
--- a/tutorials/01-basics/logistic_regression/main.py
+++ b/tutorials/01-basics/logistic_regression/main.py
@@ -70,7 +70,7 @@ with torch.no_grad():
         total += labels.size(0)
         correct += (predicted == labels).sum()
 
-    print('Accuracy of the model on the 10000 test images: {} %'.format(100 * correct / total))
+    print('Accuracy of the model on the 10000 test images: {} %'.format(100 * correct.item() / total))
 
 # Save the model checkpoint
 torch.save(model.state_dict(), 'model.ckpt')


### PR DESCRIPTION
<The variable `correct` is a tensor object, which may lead to a
RuntimeError when divided by an int. Using the method `.item()` solves
this problem. Fix #220>