### PR TITLE
update data_iter.next()

### DIFF
--- a/tutorials/01-basics/pytorch_basics/main.py
+++ b/tutorials/01-basics/pytorch_basics/main.py
@@ -121,7 +121,7 @@ train_loader = torch.utils.data.DataLoader(dataset=train_dataset,
 data_iter = iter(train_loader)
 
 # Mini-batch images and labels.
-images, labels = data_iter.next()
+images, labels = next(data_iter)
 
 # Actual usage of the data loader is as below.
 for images, labels in train_loader:


### PR DESCRIPTION
This pull request includes a small change to the `tutorials/01-basics/pytorch_basics/main.py` file. The change modifies how the next batch of images and labels is retrieved from the data iterator to improve code readability and usage consistency.

* [`tutorials/01-basics/pytorch_basics/main.py`](diffhunk://#diff-61fa1cf8803e14dbd7a3ca5b4b2ed8b2ceb6ab16a3fa0ee8fdda83a5df329388L124-R124): Changed `data_iter.next()` to `next(data_iter)` for retrieving the next batch of images and labels.